### PR TITLE
Update validators.json locale id

### DIFF
--- a/public/locales/id/validators.json
+++ b/public/locales/id/validators.json
@@ -1,20 +1,20 @@
 {
   "table": {
-    "validator": "Validador",
-    "server-country": "Server country",
-    "server-location": "Server location",
-    "cloud-private": "Cloud/private",
-    "network-asn": "Network ASN",
-    "owner-country": "Owner country",
-    "votes-for": "Votes for",
-    "last-seen": "Last seen",
-    "reserves": "Reserves",
+    "validator": "Validator",
+    "server-country": "Negara Server",
+    "server-location": "Lokasi Server",
+    "cloud-private": "Cloud/pribadi",
+    "network-asn": "ASN Jaringan",
+    "owner-country": "Negara Pemilik",
+    "votes-for": "Usulan untuk",
+    "last-seen": "Terakhir dilihat",
+    "reserves": "Cadangan",
     "text": {
-      "domain-verified-toml": "Verified domain (TOML file)",
-      "unl": "In the Unique Node List (UNL)",
-      "negative-unl": "in the Negative UNL"
+      "domain-verified-toml": "Domain terverifikasi (file TOML)",
+      "unl": "Dalam Daftar Node Unik (UNL)",
+      "negative-unl": "dalam Daftar Node Negatif (Negative UNL)"
     }
   },
-  "domain-legacy": "Domain (verifikasi lama)",
+  "domain-legacy": "Domain (verifikasi lampau)",
   "text0": "Daftar validator <1>{{url}}</1> memiliki urutan {{sequence}} dan berakhir pada {{expiration}}.<br/>Daftar ini mencakup {{validatorCount}} validator yang tercantum di bawah ini."
 }


### PR DESCRIPTION
## Proposed Change

### Description

This proposed change introduces translation updates for the JSON script to provide a more user-friendly experience for Indonesian speakers. The translation includes content related to the Validator List.

### Changes Made

- **table**: Translated table headers and added descriptions for various fields such as Validator, Server Country, Server Location, Cloud/Private, Network ASN, Owner Country, Votes For, Last Seen, Reserves, and Text with domain verification information.
- **domain-legacy**: Translated the term "Domain (legacy)" to "Domain (verifikasi lampau)."
- **text0**: Updated the text to describe the Validator List with details about sequence, expiration, and the total number of validators.

### Context

This change aims to enhance the usability of features related to the Validator List by providing accurate and clear information in Indonesian.

### Additional Notes

- Please review and provide feedback on the proposed translations.
- If there are specific terms or nuances that need adjustment, feel free to suggest changes.