### PR TITLE
fix: mobile zIndex + some small mobile styles

### DIFF
--- a/styles/components/filters.scss
+++ b/styles/components/filters.scss
@@ -51,6 +51,7 @@ $width: 340px;
 
             @media(max-width: 1300px) {
                 gap: 8px;
+                margin-bottom: 8px;
             }
         }
     }
@@ -226,6 +227,10 @@ $width: 340px;
         @media(min-width: 440px) {
             width: 38px;
             height: 38px;
+        }
+
+        @media(max-width: 440px) {
+            padding: 5px;
         }
 
         .dark & {

--- a/styles/components/header.scss
+++ b/styles/components/header.scss
@@ -161,7 +161,7 @@ header {
   right: 0;
   transform: translateX(100%);
   top: 0;
-  z-index: 4;
+  z-index: 6;
   transition: 0.5s;
   overflow: auto;
   display: flex;


### PR DESCRIPTION
Before:
![image](https://github.com/Bithomp/frontend-react/assets/46331554/dbcf5395-a22e-4ea9-a91f-cb5a5de3e610)

After: 
![image](https://github.com/Bithomp/frontend-react/assets/46331554/10359559-d96b-4e5f-bb2a-8d482e55618d)
