### PR TITLE
fix: tiles font-size in small screens

### DIFF
--- a/styles/components/tiles.scss
+++ b/styles/components/tiles.scss
@@ -88,6 +88,9 @@
             top: 25%;
             font-size: 1em;
             font-weight: bold;
+            @media(max-width: 1360px) and (min-width: 1301px) {
+              font-size: 0.9em;
+            }
           }
           .title-text {
             font-weight: bold;


### PR DESCRIPTION
on small screens from +-1360px both on Mac and Windows I reduced the font size a little. The font itself has not changed, still the same Open Sans Bold. I checked other breakpoints and I don't see any more problems with the text in tiles