### PR TITLE
Update momentjs with dayjs

### DIFF
--- a/components/Layout/Header/LangTable.js
+++ b/components/Layout/Header/LangTable.js
@@ -1,14 +1,14 @@
 import { useTranslation } from 'next-i18next'
 import { useState, useEffect } from 'react'
 
-import moment from 'moment'
-import 'moment/locale/ru' // 'ru'
-import 'moment/locale/ko' // 'ko'
-import 'moment/locale/de' // 'de'
-import 'moment/locale/es' // 'es'
-import 'moment/locale/id' // 'id'
-import 'moment/locale/ja' // 'ja'
-import 'moment/locale/fr' // 'fr'
+import dayjs from 'dayjs'
+import 'dayjs/locale/ru' // 'ru'
+import 'dayjs/locale/ko' // 'ko'
+import 'dayjs/locale/de' // 'de'
+import 'dayjs/locale/es' // 'es'
+import 'dayjs/locale/id' // 'id'
+import 'dayjs/locale/ja' // 'ja'
+import 'dayjs/locale/fr' // 'fr'
 
 import { useRouter } from 'next/router'
 import Cookies from 'universal-cookie'
@@ -32,7 +32,7 @@ export default function LanguageSwitch({ close }) {
 
   const langChange = (lang) => {
     if (lang === 'default' || lang === 'undefined' || !lang) return
-    moment.locale(lang)
+    dayjs.locale(lang)
     cookies.set('NEXT_LOCALE', lang, cookieParams)
   }
 

--- a/package.json
+++ b/package.json
@@ -37,11 +37,10 @@
     "bignumber.js": "^9.1.2",
     "buffer": "^6.0.3",
     "crypto-hash": "^2.0.1",
+    "dayjs": "^1.11.13",
     "i18n-iso-countries": "^7.4.0",
     "i18next": "^22.4.10",
     "mobile-detect": "^1.4.5",
-    "moment": "^2.29.3",
-    "moment-duration-format": "^2.3.2",
     "next": "^14.2.16",
     "next-i18next": "^13.2.1",
     "next-qrcode": "^2.5.1",
@@ -92,7 +91,6 @@
     "eslint": "8.57.0",
     "eslint-config-next": "^14.2.14",
     "husky": "^8.0.3",
-    "jquery": "^3.7.1",
     "typescript": "^4.9.5",
     "webpack": "^5.0.0"
   }

--- a/pages/validators.js
+++ b/pages/validators.js
@@ -1,6 +1,5 @@
 import { useTranslation, Trans } from 'next-i18next'
 import { useState, useEffect, memo } from 'react'
-import moment from 'moment'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import ReactCountryFlag from 'react-country-flag'
 import { useTheme } from '../components/Layout/ThemeContext'
@@ -61,8 +60,6 @@ const fixCountry = (country) => {
   //accept UK as a country code for GB
   return country?.toUpperCase() === 'UK' ? 'GB' : country
 }
-
-moment.relativeTimeThreshold('ss', devNet ? 36 : 6)
 
 export default function Validators({ amendment, initialData, initialErrorMessage }) {
   const [validators, setValidators] = useState(null)

--- a/utils/format.js
+++ b/utils/format.js
@@ -1,25 +1,27 @@
 import { Buffer } from 'buffer'
+import dayjs from 'dayjs'
+import * as durationPlugin from 'dayjs/plugin/duration'
+import * as relativeTimePlugin from 'dayjs/plugin/relativeTime'
+import Image from 'next/image'
 import Link from 'next/link'
-import React from 'react'
 import { Trans } from 'next-i18next'
-import moment from 'moment'
-import momentDurationFormatSetup from 'moment-duration-format'
+import React from 'react'
 
+import CopyButton from '../components/UI/CopyButton'
 import LinkIcon from '../public/images/link.svg'
+import { mpUrl } from './nft'
 import {
-  stripText,
-  nativeCurrency,
-  nativeCurrenciesImages,
   avatarServer,
   devNet,
   isAmountInNativeCurrency,
+  nativeCurrency,
+  nativeCurrenciesImages,
+  stripText,
   xls14NftValue
 } from '.'
-import { mpUrl } from './nft'
-import Image from 'next/image'
-import CopyButton from '../components/UI/CopyButton'
 
-momentDurationFormatSetup(moment)
+dayjs.extend(durationPlugin)
+dayjs.extend(relativeTimePlugin)
 
 export const NiceNativeBalance = ({ amount }) => {
   return (
@@ -734,13 +736,13 @@ export const timeFromNow = (timestamp, i18n, type) => {
   } else {
     lang = i18n.language.slice(0, 2)
   }
-  moment.locale(lang)
+  dayjs.locale(lang)
 
   if (type === 'ripple') {
     timestamp += 946684800 //946684800 is the difference between Unix and Ripple timestamps
   }
 
-  return <span suppressHydrationWarning>{moment(timestamp * 1000, 'unix').fromNow()}</span>
+  return <span suppressHydrationWarning>{dayjs(timestamp * 1000, 'unix').fromNow()}</span>
 }
 
 export const fullDateAndTime = (timestamp, type = null, options) => {
@@ -803,30 +805,22 @@ export const expirationExpired = (t, timestamp, type) => {
 }
 
 export const duration = (t, seconds, options) => {
-  /*
-    years:   Y or y
-    months:  M
-    weeks:   W or w
-    days:    D or d
-    hours:   H or h
-    minutes: m
-    seconds: s
-    ms:      S
-  */
   if (!seconds) return ''
-  return moment
-    .duration(seconds, 'seconds')
-    .format(
-      'd[' +
-        t('units.days-short') +
-        '] h[' +
-        t('units.hours-short') +
-        '] m[' +
-        t('units.minutes-short') +
-        ']' +
-        (options?.seconds ? ' s[' + t('units.seconds-short') + ']' : ''),
-      { trim: 'both' }
-    )
+
+  const dur = dayjs.duration(seconds, 'seconds')
+  const parts = []
+
+  const days = Math.floor(dur.asDays())
+  const hours = dur.hours()
+  const minutes = dur.minutes()
+  const secs = dur.seconds()
+
+  if (days > 0) parts.push(`${days}${t('units.days-short')}`)
+  if (hours > 0) parts.push(`${hours}${t('units.hours-short')}`)
+  if (minutes > 0) parts.push(`${minutes}${t('units.minutes-short')}`)
+  if (options?.seconds && secs > 0) parts.push(`${secs}${t('units.seconds-short')}`)
+  
+  return parts.join(' ')
 }
 
 //need to make dynamic fraction digits

--- a/yarn.lock
+++ b/yarn.lock
@@ -4727,6 +4727,11 @@ date-fns@^2.29.3, date-fns@^2.30.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
+dayjs@^1.11.13:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
+
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@~4.3.1, debug@~4.3.2:
   version "4.3.7"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz"
@@ -6380,11 +6385,6 @@ jiti@^2.1.2:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.4.1.tgz#4de9766ccbfa941d9b6390d2b159a4b295a52e6b"
   integrity sha512-yPBThwecp1wS9DmoA4x4KR2h3QoslacnDR8ypuFM962kI4/456Iy1oHx2RAgh4jfZNdn0bctsdadceiBUgpU1g==
 
-jquery@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
-  integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
-
 js-sha3@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
@@ -6766,16 +6766,6 @@ mobile-detect@^1.4.5:
   version "1.4.5"
   resolved "https://registry.npmjs.org/mobile-detect/-/mobile-detect-1.4.5.tgz"
   integrity sha512-yc0LhH6tItlvfLBugVUEtgawwFU2sIe+cSdmRJJCTMZ5GEJyLxNyC/NIOAOGk67Fa8GNpOttO3Xz/1bHpXFD/g==
-
-moment-duration-format@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.3.2.tgz"
-  integrity sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ==
-
-moment@^2.29.3:
-  version "2.30.1"
-  resolved "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz"
-  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 motion@10.16.2:
   version "10.16.2"


### PR DESCRIPTION
As Moment.js is now deprecated, I’ve updated it to use the Day.js library (https://day.js.org/en/). This also reduces the JS bundle size by 17 KB 🚀 