### PR TITLE
Load 'i18n-iso-countries' dynamically

### DIFF
--- a/components/Admin/BillingCountry.js
+++ b/components/Admin/BillingCountry.js
@@ -92,7 +92,7 @@ export default function BillingCountry({ billingCountry, setBillingCountry, choo
           {billingCountry && (
             <>
               Your billing country is{' '}
-              <a onClick={() => setChoosingCountry(true)}>{countries.getNameTranslated(billingCountry)}</a>
+              <a onClick={() => setChoosingCountry(true)}>{countries?.getNameTranslated?.(billingCountry) || billingCountry}</a>
             </>
           )}
         </>

--- a/components/Admin/BillingCountry.js
+++ b/components/Admin/BillingCountry.js
@@ -10,7 +10,15 @@ import { axiosAdmin } from '../../utils/axios'
 export default function BillingCountry({ billingCountry, setBillingCountry, choosingCountry, setChoosingCountry }) {
   const router = useRouter()
   const { i18n } = useTranslation()
-  const countries = countriesTranslated(i18n.language)
+  const [countries, setCountries] = useState(null)
+
+  useEffect(() => {
+    const loadCountries = async () => {
+      const data = await countriesTranslated(i18n.language)
+      setCountries(data)
+    }
+    loadCountries()
+  }, [i18n.language])
 
   const [loading, setLoading] = useState(true) //keep true for country select
 

--- a/components/UI/CountrySelect.js
+++ b/components/UI/CountrySelect.js
@@ -7,7 +7,7 @@ import { useLocalStorage, countriesTranslated } from '../../utils'
 
 export default function CountrySelect({ countryCode, setCountryCode, type }) {
   const { i18n } = useTranslation()
-  const countries = countriesTranslated(i18n.language)
+  const [countries, setCountries] = useState(null)
 
   const countryArr = countries.countryArr
 
@@ -29,6 +29,14 @@ export default function CountrySelect({ countryCode, setCountryCode, type }) {
       }
     }
   }
+
+  useEffect(() => {
+    const loadCountries = async () => {
+      const data = await countriesTranslated(i18n.language)
+      setCountries(data)
+    }
+    loadCountries()
+  }, [i18n.language])
 
   useEffect(() => {
     if (type === 'onlySelect') {

--- a/components/UI/CountrySelect.js
+++ b/components/UI/CountrySelect.js
@@ -9,7 +9,7 @@ export default function CountrySelect({ countryCode, setCountryCode, type }) {
   const { i18n } = useTranslation()
   const [countries, setCountries] = useState(null)
 
-  const countryArr = countries.countryArr
+  const countryArr = countries?.countryArr || []
 
   const [savedCountry, setSavedCounty] = useLocalStorage('country')
   const [selectCountry, setSelectCountry] = useState({ value: '', label: '' })
@@ -21,7 +21,7 @@ export default function CountrySelect({ countryCode, setCountryCode, type }) {
       const countryCode = json.country.toUpperCase()
       setSelectCountry({
         value: countryCode,
-        label: countries.getNameTranslated(countryCode)
+        label: countries?.getNameTranslated?.(countryCode) || countryCode
       })
       setCountryCode(countryCode)
       if (type !== 'onlySelect') {

--- a/components/UI/CountrySelect.js
+++ b/components/UI/CountrySelect.js
@@ -13,12 +13,11 @@ export default function CountrySelect({ countryCode, setCountryCode, type }) {
 
   const hasRun = useRef(false)
 
-  const loadCountries = async () => {
-    const data = await countriesTranslated(i18n.language)
-    setCountries(data)
-  }
-
   useEffect(() => {
+    const loadCountries = async () => {
+      const data = await countriesTranslated(i18n.language)
+      setCountries(data)
+    }
     loadCountries()
   }, [i18n.language])
 

--- a/components/UI/CountryWithFlag.js
+++ b/components/UI/CountryWithFlag.js
@@ -19,7 +19,6 @@ export default function CountryWithFlag({ countryCode, type }) {
 
   if (!countryCode) return ''
   if (countryCode === 'unknown') return <b>Unknown</b>
-  if (!countries) return countryCode
 
   return (
     <>
@@ -30,7 +29,7 @@ export default function CountryWithFlag({ countryCode, type }) {
           lineHeight: '1.5em'
         }}
       />{' '}
-      {type === 'code' ? countryCode : countries.getNameTranslated(countryCode)}
+      {type === 'code' ? countryCode : countries ? countries.getNameTranslated(countryCode) : countryCode}
     </>
   )
 }

--- a/components/UI/CountryWithFlag.js
+++ b/components/UI/CountryWithFlag.js
@@ -1,13 +1,25 @@
-import ReactCountryFlag from 'react-country-flag'
-import { countriesTranslated } from '../../utils'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'next-i18next'
+
+import ReactCountryFlag from 'react-country-flag'
+
+import { countriesTranslated } from '../../utils'
 
 export default function CountryWithFlag({ countryCode, type }) {
   const { i18n } = useTranslation()
-  if (!countryCode) return ''
-  const countries = countriesTranslated(i18n.language)
+  const [countries, setCountries] = useState(null)
 
+  useEffect(() => {
+    const loadCountries = async () => {
+      const data = await countriesTranslated(i18n.language)
+      setCountries(data)
+    }
+    loadCountries()
+  }, [i18n.language])
+
+  if (!countryCode) return ''
   if (countryCode === 'unknown') return <b>Unknown</b>
+  if (!countries) return countryCode
 
   return (
     <>

--- a/pages/validators.js
+++ b/pages/validators.js
@@ -76,8 +76,15 @@ export default function Validators({ amendment, initialData, initialErrorMessage
   const { t, i18n } = useTranslation()
   const windowWidth = useWidth()
   const { theme } = useTheme()
+  const [countries, setCountries] = useState(null)
 
-  const countries = countriesTranslated(i18n.language)
+  useEffect(() => {
+    const loadCountries = async () => {
+      const data = await countriesTranslated(i18n.language)
+      setCountries(data)
+    }
+    loadCountries()
+  }, [i18n.language])
 
   const showTime = ({ time }) => {
     if (!time) return 'N/A'
@@ -225,7 +232,7 @@ export default function Validators({ amendment, initialData, initialErrorMessage
           />
           {country.toLowerCase() !== 'eu' && (
             <span className="tooltiptext right no-brake">
-              {typeName}: {countries.getNameTranslated(country)}
+              {typeName}: {countries?.getNameTranslated?.(country) || country}
             </span>
           )}
         </span>

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Buffer } from 'buffer'
 import { decodeAccountID, isValidClassicAddress } from 'ripple-address-codec'
-import countries from 'i18n-iso-countries'
 import Cookies from 'universal-cookie'
 
 export const safeClone = (obj) => {
@@ -87,26 +86,30 @@ export const periodDescription = (periodName) => {
   }
 }
 
-export const countriesTranslated = (language) => {
+export const countriesTranslated = async (language) => {
   let lang = language.slice(0, 2)
   if (language === 'default') {
     lang = 'en'
   }
+
   const notSupportedLanguages = ['my'] // supported "en", "ru", "ja", "ko", "fr" etc
   if (notSupportedLanguages.includes(lang)) {
     lang = 'en'
   }
-  const languageData = require('i18n-iso-countries/langs/' + lang + '.json')
+
+  const countries = await import('i18n-iso-countries')
+  const languageData = await import(`i18n-iso-countries/langs/${lang}.json`)
   countries.registerLocale(languageData)
-  countries.getNameTranslated = (code) => {
+
+  const getNameTranslated = (code) => {
     return countries.getName(code, lang, { select: 'official' })
   }
 
-  countries.getNamesTranslated = () => {
+  const getNamesTranslated = () => {
     return countries.getNames(lang, { select: 'official' })
   }
 
-  const countryObj = countries.getNamesTranslated()
+  const countryObj = getNamesTranslated()
   const countryArr = Object.entries(countryObj).map(([key, value]) => {
     return {
       label: value,
@@ -114,9 +117,12 @@ export const countriesTranslated = (language) => {
     }
   })
   countryArr.sort((a, b) => a.label.localeCompare(b.label, lang))
-  countries.countryArr = countryArr
 
-  return countries
+  return {
+    countryArr,
+    getNameTranslated,
+    getNamesTranslated
+  }
 }
 
 export const chartSpan = (period) => {


### PR DESCRIPTION
Reducing `app.js` bundle size by loading 'i18n-iso-countries' dynamically. Bundle size is reduced on ~148kB.

It affects pages:
`pages/nodes.js`
`pages/username.js`
`pages/validators.js`
`pages/admin/subscriptions.js`
`pages/nft/[[..id]].js`