### PR TITLE
Improve text contrast in the light theme

### DIFF
--- a/styles/components/footer.scss
+++ b/styles/components/footer.scss
@@ -4,6 +4,12 @@ footer {
   color: var(--text-contrast);
   transition: background-color .5s, color .5s;
   min-height: 257px;
+  a, .link {
+    color: var(--footer-link);
+    &:hover {
+      color: var(--footer-link-hover);
+    }
+  }
   @media screen and (max-width: 1300px) {
     min-height: 476px;
   }
@@ -34,12 +40,6 @@ footer {
   vertical-align: top;
   margin-bottom: 10px;
   font-size: 14px;
-  a,
-  .link {
-    &:hover {
-      color: var(--text-contrast);
-    }
-  }
 }
 
 .footer-menu-header {

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -10,20 +10,22 @@ body {
   --background-input: white;
   --background-input-readonly: #e9ecef;
   --text-main: #333333;
-  --text-secondary: #999999;
+  --text-secondary: #62636C;
   --text-contrast: white;
   --text-oposite: white;
-  --accent-link: #00B1C1;
+  --accent-link: #00808E;
   --accent-link-hover: #002C37;
-  --accent-icon: #3FA3B5;
+  --footer-link: #00B1C1;
+  --footer-link-hover: #66D0DA;
+  --accent-icon: #00828E;
   --unaccent-icon: rgba(63, 163, 181, .5);
   --shadow: rgba(0, 0, 0, 0.2);
   --red: #D23A1C;
   --green: #14913E;
   --orange: #FCAC45;
   --purple: #800080;
-}
-body.dark {
+  }
+  body.dark {
   --background-header: #031B21;
   --background-block: #031B21;
   --background-main: #090909;
@@ -41,20 +43,22 @@ body.dark {
   --accent-link: #66D0DA;
   --accent-link-hover: white;
   --accent-icon: #00B1C1;
+  --footer-link: #66D0DA;
+  --footer-link-hover: white;
   --unaccent-icon: rgba(0, 177, 193, .5);
   --shadow: rgba(255, 255, 255, 0.3);
   --red: #E48977;
   --green: #62C683;
   --orange: #FAD29E;
   --purple: #EE82EE;
-}
-
-body[data-networkname*="xahau"] {
+  }
+  
+  body[data-networkname*="xahau"] {
   --background-header: #0E233F;
   --background-block: #0E233F;
   --background-footer: #061322;
   &.dark {
-    --background-header: #061322;
-    --background-block: #061322;
+  --background-header: #061322;
+  --background-block: #061322;
   }
-}
+  }


### PR DESCRIPTION
Improve text contrast for the light theme. It's easier to read and it improves accessibility score as well. Accessibility 89 -> 93.

## How it was
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/30019484-16fb-4bde-995f-53702c13a6c1" />

## How it's suggested
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/53786299-1580-4e8a-8c9d-f5f2f3eb1c51" />
