### PR TITLE
Rename css class 'flex' to 'flex-container' in 'ui.scss'

### DIFF
--- a/pages/account/[[...id]].js
+++ b/pages/account/[[...id]].js
@@ -328,7 +328,7 @@ export default function Account({
                                 <tbody>
                                   <tr>
                                     <td colSpan="2" className="no-padding">
-                                      <div className="flex flex-center">
+                                      <div className="flex-container flex-center">
                                         {!account?.address && (
                                           <button
                                             className="button-action button-wide thin"
@@ -476,7 +476,7 @@ export default function Account({
                                       showYearDropdown
                                     />
                                   </div>
-                                  <div className="flex flex-center">
+                                  <div className="flex-container flex-center">
                                     <button
                                       onClick={() => setLedgerTimestamp(ledgerTimestampInput)}
                                       className="button-action thin button-wide"

--- a/pages/admin/pro/index.js
+++ b/pages/admin/pro/index.js
@@ -441,7 +441,7 @@ export default function Pro({ account, setSignRequest, refreshPage, subscription
                 <>
                   <br />
                   <br />
-                  <div className="flex flex-center">
+                  <div className="flex-container flex-center">
                     <span
                       style={width > 851 ? { width: 'calc(70% - 20px)' } : { width: '100%', marginBottom: '-20px' }}
                     >

--- a/pages/admin/watchlist.js
+++ b/pages/admin/watchlist.js
@@ -443,7 +443,7 @@ export default function Watchlist({ selectedCurrency, account, subscriptionExpir
               <>
                 {width > 851 && <br />}
                 <br />
-                <div className="flex flex-center">
+                <div className="flex-container flex-center">
                   <span style={width > 851 ? { width: 'calc(70% - 20px)' } : { width: '100%', marginBottom: '-20px' }}>
                     <AddressInput
                       title="Address or NFT"

--- a/pages/distribution.js
+++ b/pages/distribution.js
@@ -122,7 +122,7 @@ export default function Distribution({ selectedCurrency, fiatRate }) {
       />
       <div className="content-center">
         <h1 className="center">{t('menu.network.distribution', { nativeCurrency })}</h1>
-        <div className="flex">
+        <div className="flex-container">
           <div className="grey-box">{t('desc', { ns: 'distribution', nativeCurrency })}</div>
           <div className="grey-box">
             {loading ? (

--- a/pages/domains.js
+++ b/pages/domains.js
@@ -84,7 +84,7 @@ export default function Domains({ setSignRequest }) {
       <SEO title={t('menu.network.verified-domains')} />
       <div className="content-text">
         <h1 className="center">{t('menu.network.verified-domains')}</h1>
-        <div className="flex">
+        <div className="flex-container">
           <div className="grey-box">
             <h4>{t('domain-verification', { ns: 'domains' })}</h4>
             <p>{t('domain-verification-desc', { ns: 'domains' })}</p>

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -71,7 +71,7 @@ export default function Donate() {
         <h1 className="center">
           {t('menu.donate')} <span className="red">❤</span>
         </h1>
-        <div className="flex">
+        <div className="flex-container">
           <div className="grey-box">
             <Image
               src="/images/donate.png"

--- a/pages/genesis.js
+++ b/pages/genesis.js
@@ -66,7 +66,7 @@ export default function Genesis() {
 
         {/* TODO add description for other networks like in ledger/[[...ledgerindex]].js */}
         {network === 'mainnet' && (
-          <div className="flex">
+          <div className="flex-container">
             <div className="grey-box">
               <Trans i18nKey="genesis.text0">
                 The ledger <b>32570</b> is the earliest ledger available, approximately the first week of XRPL history,

--- a/pages/governance/[[...id]].js
+++ b/pages/governance/[[...id]].js
@@ -453,7 +453,7 @@ export default function Governance({ id, setSignRequest, refreshPage, account })
           </div>
         )}
         <br />
-        <div className="flex flex-center">
+        <div className="flex-container flex-center">
           <div className="div-with-table">
             <h4 className="center">{t('table.members', { ns: 'governance' })}</h4>
             <table className="table-large shrink">
@@ -551,7 +551,7 @@ export default function Governance({ id, setSignRequest, refreshPage, account })
           </div>
         </div>
         <br />
-        <div className="flex flex-center">
+        <div className="flex-container flex-center">
           <div className="div-with-table">
             <h4 className="center">{t('table.seat-votes', { ns: 'governance' })}</h4>
             <table className="table-large shrink">
@@ -687,7 +687,7 @@ export default function Governance({ id, setSignRequest, refreshPage, account })
           )}
         </div>
         <br />
-        <div className="flex flex-center">
+        <div className="flex-container flex-center">
           <div className="div-with-table">
             <h4 className="center">{t('table.reward-rate-votes', { ns: 'governance' })}</h4>
             <table className="table-large shrink">
@@ -824,7 +824,7 @@ export default function Governance({ id, setSignRequest, refreshPage, account })
           )}
         </div>
         <br />
-        <div className="flex flex-center">
+        <div className="flex-container flex-center">
           <div className="div-with-table">
             <h4 className="center">{t('table.reward-delay-votes', { ns: 'governance' })}</h4>
             <table className="table-large shrink">
@@ -961,7 +961,7 @@ export default function Governance({ id, setSignRequest, refreshPage, account })
           )}
         </div>
         <br />
-        <div className="flex flex-center">
+        <div className="flex-container flex-center">
           <div className="div-with-table">
             <h4 className="center">{t('table.hook-votes', { ns: 'governance' })}</h4>
             <table className="table-large shrink">

--- a/pages/ledger/[[...ledgerIndex]].js
+++ b/pages/ledger/[[...ledgerIndex]].js
@@ -215,7 +215,7 @@ export default function Ledger({ pageMeta, ledgerIndexQuery }) {
             )}
           </>
         ) : (
-          <div className="flex">
+          <div className="flex-container">
             <div className="grey-box">
               {!ledgerVersion && ledgerVersion !== '' ? (
                 <p className="center">{t('ledger-not-found', { ns: 'ledger' })}</p>

--- a/pages/nft-minters.js
+++ b/pages/nft-minters.js
@@ -200,7 +200,7 @@ export default function NftMinters({ periodQuery }) {
             tabs={true}
           />
         </div>
-        <div className="flex">
+        <div className="flex-container">
           <div className="grey-box">{t('desc', { ns: 'nft-minters' })}</div>
           <div className="grey-box">
             {loading ? (

--- a/pages/nft-volumes/[issuer].js
+++ b/pages/nft-volumes/[issuer].js
@@ -352,7 +352,7 @@ export default function NftVolumes({
           ) : (
             <>
               {chartIssuers.length > 0 && chartVolumes.length > 0 && (
-                <div className="flex" style={{ marginLeft: '10px', justifyContent: 'center' }}>
+                <div className="flex-container" style={{ marginLeft: '10px', justifyContent: 'center' }}>
                   <div style={chartDivStyle}>
                     <h3>
                       {t('sales-chart', { ns: 'nft-volumes' })} / {t('volumes-chart', { ns: 'nft-volumes' })} (

--- a/pages/nft-volumes/index.js
+++ b/pages/nft-volumes/index.js
@@ -1072,7 +1072,7 @@ export default function NftVolumes({
                 ) : (
                   <>
                     {chartIssuers.length > 0 && chartVolumes.length > 0 && (
-                      <div className="flex" style={{ marginLeft: '10px', justifyContent: 'center' }}>
+                      <div className="flex-container" style={{ marginLeft: '10px', justifyContent: 'center' }}>
                         <div style={chartDivStyle}>
                           <h3>
                             {t('sales-chart', { ns: 'nft-volumes' })} / {t('volumes-chart', { ns: 'nft-volumes' })} (

--- a/pages/nodes.js
+++ b/pages/nodes.js
@@ -74,7 +74,7 @@ export default function Nodes({ initialData, initialErrorMessage }) {
           {data?.crawl_time && <> (updated {timeFromNow(data.crawl_time, i18n)}).</>}
         </p>
 
-        <div className="flex flex-center">
+        <div className="flex-container flex-center">
           <div className="div-with-table">
             <h4 className="center">Versions</h4>
             {data?.summary?.versions?.length > 0 && (

--- a/pages/unl-report.js
+++ b/pages/unl-report.js
@@ -110,7 +110,7 @@ export default function UNLreport() {
       <SEO title={t('header', { ns: 'unl-report' })} />
       <div className="content-text">
         <h1 className="center">{t('header', { ns: 'unl-report' })}</h1>
-        <div className="flex">
+        <div className="flex-container">
           <div className="grey-box center">
             <Trans i18nKey="desc" ns="unl-report">
               Here you can find UNL report for Ledger <b>{{ ledgerIndex: rawData?.ledgerIndex || '' }}</b>, ledger

--- a/pages/validators.js
+++ b/pages/validators.js
@@ -511,7 +511,7 @@ export default function Validators({ amendment, initialData, initialErrorMessage
       <div className="content-text">
         <h1 className="center">{t('menu.network.validators')}</h1>
         <NetworkPagesTab tab="validators" />
-        <div className="flex center">
+        <div className="flex-container center">
           <div className="grey-box">
             {validators && (
               <Trans i18nKey="text0" ns="validators">
@@ -531,7 +531,7 @@ export default function Validators({ amendment, initialData, initialErrorMessage
           </div>
         </div>
 
-        <div className="flex flex-center">
+        <div className="flex-container flex-center">
           {developerMode && (
             <div className="div-with-table">
               <h4 className="center">Versions</h4>

--- a/styles/ui.scss
+++ b/styles/ui.scss
@@ -461,7 +461,7 @@ table {
   text-align: right !important;
 }
 
-.flex {
+.flex-container {
   display: flex;
   gap: 20px 20px;
   flex-wrap: wrap;


### PR DESCRIPTION
Suggest renaming of css class `flex` to `flex-container`. 
- I often use tailwind classes to generate mockups for interfaces. And `flex` from `ui.scss` conflicts with tailwinds'.
- `flex-container` is more specific about and better follows css naming conventions.

I greped for existing usage of `flex` and I think I replaced in all places.