### PR TITLE
Add '@' as import alias

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,9 @@ module.exports = withBundleAnalyzer({
       test: /\.svg$/,
       use: ['@svgr/webpack']
     })
+    config.resolve = config.resolve || {};
+    config.resolve.alias = config.resolve.alias || {};
+    config.resolve.alias['@'] = __dirname;
     return config
   },
   images: {


### PR DESCRIPTION
Add `@` import alias that I started to use in some branches, but it's not merged yet.

Instead of relative paths like `../../../components/Button`, you can write `@/components/Button`, making easier to read imo.
