### PR TITLE
currencyDetails=true for displaying LP tokens in token list and search

### DIFF
--- a/components/UI/TokenSelector.js
+++ b/components/UI/TokenSelector.js
@@ -110,7 +110,7 @@ export default function TokenSelector({ value, onChange, excludeNative = false, 
             tokens = addNativeCurrencyIfNeeded(tokens, excludeNative)
           } else {
             // Fallback to original behavior if no destination address
-            const response = await axios('v2/trustlines/tokens?limit=' + limit)
+            const response = await axios('v2/trustlines/tokens?limit=' + limit + '&currencyDetails=true')
             tokens = response.data?.tokens || []
             if (!excludeNative) {
               setSearchResults([{ currency: nativeCurrency }, ...tokens])
@@ -144,7 +144,7 @@ export default function TokenSelector({ value, onChange, excludeNative = false, 
           setSearchResults(tokensWithNative)
         } else {
           // Fallback to original search behavior
-          const response = await axios(`v2/trustlines/tokens/search/${searchQuery}?limit=${limit}`)
+          const response = await axios(`v2/trustlines/tokens/search/${searchQuery}?limit=${limit}&currencyDetails=true`)
           const tokens = response.data?.tokens || []
           const tokensWithNative = addNativeCurrencyIfNeeded(tokens, excludeNative, searchQuery)
           setSearchResults(tokensWithNative)

--- a/pages/services/trustline.js
+++ b/pages/services/trustline.js
@@ -77,7 +77,7 @@ export default function TrustSet({ setSignRequest }) {
     try {
       // Try to get token supply from API if available
       const response = await axios(
-        `v2/trustlines/tokens?currency=${selectedToken.currency}&issuer=${selectedToken.issuer}`
+        `v2/trustlines/tokens?currency=${selectedToken.currency}&issuer=${selectedToken.issuer}&currencyDetails=true`
       )
       const token = response.data?.tokens[0]
 

--- a/pages/tokens.js
+++ b/pages/tokens.js
@@ -63,7 +63,7 @@ export async function getServerSideProps(context) {
   try {
     const res = await axiosServer({
       method: 'get',
-      url: 'v2/trustlines/tokens?limit=100&order=rating',
+      url: 'v2/trustlines/tokens?limit=100&order=rating&currencyDetails=true',
       headers: passHeaders(req)
     }).catch((error) => {
       initialErrorMessage = error.message
@@ -112,6 +112,7 @@ export default function Tokens({
     parts.push('v2/trustlines/tokens')
     parts.push(`?limit=${limit}`)
     parts.push(`&order=${order}`)
+    parts.push(`&currencyDetails=true`)
     if (issuer) {
       parts.push(`&issuer=${encodeURIComponent(issuer)}`)
     }


### PR DESCRIPTION
# Issue
[update the token list and token search features to use the currencyDetails=true parameter when fetching token data. This is necessary to properly display LP tokens](https://github.com/Bithomp/frontend-react/issues/461).