### PR TITLE
Timemachine API calls

### DIFF
--- a/pages/account/[[...id]].js
+++ b/pages/account/[[...id]].js
@@ -550,7 +550,11 @@ export default function Account({
                             escrowList={objects?.escrowList}
                           />
 
-                          <RecentTransactions userData={userData} ledgerTimestamp={ledgerTimestamp} />
+                          <RecentTransactions 
+                            userData={userData} 
+                            ledgerTimestamp={ledgerTimestamp}
+                            parentLoading={loading}
+                          />
                           {data?.ledgerInfo?.activated && !gateway && (
                             <ObjectsData
                               account={account}


### PR DESCRIPTION
# Issue
[When using a timemachine, the react sends two API calls to transactions. We should have only one call. Kindly fix it.](https://github.com/Bithomp/frontend-react/compare/main...pandablue0809:feat/423/timemachine-api-call?expand=1)

