### PR TITLE
/trustline - show token description

### DIFF
--- a/components/UI/TokenSelector.js
+++ b/components/UI/TokenSelector.js
@@ -7,7 +7,6 @@ import axios from 'axios'
 import {
   avatarServer,
   nativeCurrency,
-  isNativeCurrency,
   nativeCurrenciesImages,
   useWidth,
   setTabParams
@@ -134,22 +133,8 @@ export default function TokenSelector({
 
     const timeout = setTimeout(async () => {
       if (!searchQuery) {
-        // Only apply the early return logic when there's no destination address
-        // When destination address is provided, we always want to fetch fresh data
-        if (!destinationAddress) {
-          // do not reload default token list if it's already loaded
-          // when searched for native currency, we also add the native currency on top,
-          // so check that it's not that case before canceling the search
-          if (
-            isNativeCurrency(searchResults[0]) &&
-            !niceCurrency(searchResults[1]?.currency)?.toLowerCase().startsWith(nativeCurrency.toLowerCase())
-          )
-            return
-        } else {
-          // For destination address case, check if we already have results loaded
-          if (searchResults.length > 0) {
-            return
-          }
+        if (searchResults.length > 0) {
+          return
         }
 
         setIsLoading(true)

--- a/pages/services/trustline.js
+++ b/pages/services/trustline.js
@@ -276,8 +276,11 @@ export default function TrustSet({ setSignRequest, currencyQuery, currencyIssuer
                 currencyQueryName="currency"
               />
               {selectedToken.description && (
-                <div>
-                  <span className="grey">{selectedToken.description}</span>
+                <div style={{ marginTop: 10 }}>
+                  <span className="grey">
+                    <b>Description:</b> {selectedToken.description}
+                  </span>
+                  <br />
                   <br />
                   <span className="orange">
                     We do not take responsibility for the accuracy of the token descriptions or related information. Users should always do their own research (DYOR). The content is for informational purposes only, not financial advice.

--- a/pages/services/trustline.js
+++ b/pages/services/trustline.js
@@ -217,6 +217,7 @@ export default function TrustSet({ setSignRequest, currencyQuery, currencyIssuer
       setError(err.message)
     }
   }
+  console.log(selectedToken)
 
   return (
     <>
@@ -274,6 +275,15 @@ export default function TrustSet({ setSignRequest, currencyQuery, currencyIssuer
                 excludeNative={true}
                 currencyQueryName="currency"
               />
+              {selectedToken.description && (
+                <div>
+                  <span className="grey">{selectedToken.description}</span>
+                  <br />
+                  <span className="orange">
+                    We do not take responsibility for the accuracy of the token descriptions or related information. Users should always do their own research (DYOR). The content is for informational purposes only, not financial advice.
+                  </span>
+                </div>
+              )}
             </div>
           ) : (
             // Advanced Mode


### PR DESCRIPTION
# Issue
[when selecting a token, display the token description and other related information – we already have this data in our database.
](https://github.com/Bithomp/frontend-react/issues/508)
