### PR TITLE
/tx page - add balance changes link 

### DIFF
--- a/components/Transaction/TransactionCard.js
+++ b/components/Transaction/TransactionCard.js
@@ -57,6 +57,7 @@ export const TransactionCard = ({
   const [showRawData, setShowRawData] = useState(false)
   const [showRawMeta, setShowRawMeta] = useState(false)
   const [showAdditionalData, setShowAdditionalData] = useState(false)
+  const [showBalanceChanges, setShowBalanceChanges] = useState(false)
 
   if (!data) return null
 
@@ -416,7 +417,7 @@ export const TransactionCard = ({
                     ))}
                   {/* keep here outcome?.balanceChanges.length, to hide simple xrp and to show iou payments that are filtered when gateway doesn't have a transfer fee */}
                   {tx?.TransactionType !== 'UNLReport' &&
-                    (outcome?.balanceChanges?.length > 2 || notFullySupported) && (
+                    (outcome?.balanceChanges?.length > 2 || notFullySupported || showBalanceChanges) && (
                       <>
                         {filteredBalanceChanges?.length > 1 && (
                           <tr>
@@ -491,6 +492,14 @@ export const TransactionCard = ({
                         Additional data
                       </span>{' '}
                       |{' '}
+                      {!notFullySupported && (
+                        <>
+                          <span className="link" onClick={() => setShowBalanceChanges(!showBalanceChanges)}>
+                            Balance changes
+                          </span>{' '}
+                          |{' '}
+                        </>
+                      )}
                       <span className="link" onClick={() => setShowRawData(!showRawData)}>
                         {t('table.raw-data')}
                       </span>{' '}


### PR DESCRIPTION
# Issue
[In transactions we have “Show more” we need to add there after Aditional data, a new clickable link “balance changes”, that will show the “Affected accounts” which we show now only for the “notFully supported”.. basically “notFully supported” will show it open right away, the rest will have it hidden, but visible by clicking on “balance changes” in show more.
](https://github.com/Bithomp/frontend-react/issues/562)
