### PR TITLE
/services/trustline don't show xrp and xah in the list

### DIFF
--- a/pages/services/trustline.js
+++ b/pages/services/trustline.js
@@ -45,7 +45,7 @@ export const getServerSideProps = async (context) => {
   } = query
   return {
     props: {
-      currencyQuery: currency || nativeCurrency,
+      currencyQuery: currency || '',
       currencyIssuerQuery: currencyIssuer || '',
       modeQuery: mode || 'simple',
       issuerQuery: issuer || '',
@@ -84,7 +84,6 @@ export default function TrustSet({
   // Simple mode state
   const [selectedToken, setSelectedToken] = useState({ currency: currencyQuery, issuer: currencyIssuerQuery })
   const [tokenSupply, setTokenSupply] = useState(null)
-
   // Advanced mode state
   const [issuer, setIssuer] = useState(issuerQuery || currencyIssuerQuery)
   const [currency, setCurrency] = useState({ currency: currencyQuery })


### PR DESCRIPTION
# Issue
[remove xrp and xah in the list](https://github.com/Bithomp/frontend-react/issues/591)