### PR TITLE
Tokens Section on /account Page - add links

### DIFF
--- a/components/Account/IOUData.js
+++ b/components/Account/IOUData.js
@@ -9,7 +9,7 @@ import {
 } from '../../utils/format'
 import { LinkAccount } from '../../utils/links'
 import { useWidth } from '../../utils'
-import { FaSnowflake, FaLock, FaExchangeAlt, FaIcicles, FaShieldAlt, FaChartLine } from 'react-icons/fa'
+import { FaSnowflake, FaLock, FaExchangeAlt, FaIcicles, FaShieldAlt, FaInfoCircle } from 'react-icons/fa'
 import { subtract } from '../../utils/calc'
 import { useTranslation } from 'next-i18next'
 import { useState, useEffect } from 'react'
@@ -104,7 +104,7 @@ const LimitsIcon = ({ trustline }) => {
 
   return (
     <span className="tooltip">
-      <FaChartLine style={{ fontSize: 18, marginBottom: -4 }} />
+      <FaInfoCircle style={{ fontSize: 18, marginBottom: -4 }} />
       <span className="tooltiptext no-brake">{tooltipText}</span>
     </span>
   )
@@ -254,8 +254,16 @@ export default function IOUData({ address, rippleStateList, ledgerTimestamp, pag
         <thead>
           <tr>
             <th colSpan="100">
-              {tokensCountText(rippleStateList)} {t('menu.tokens')} {historicalTitle} [
-              <a href={'/explorer/' + address}>Old View</a>]
+              {tokensCountText(rippleStateList)} {t('menu.tokens')} {historicalTitle}
+              {account?.address && rippleStateList?.length ? (
+                <>
+                  [<a href={'/services/trustline?address=' + address}>Add a token</a>]
+                </>
+              ) : (
+                <>
+                  [<a href={'/explorer/' + address}>Old View</a>]
+                </>
+              )}
               {totalBalance > 0 && (
                 <span style={{ float: 'right' }}>
                   Total worth:{' '}

--- a/components/Account/IOUData.js
+++ b/components/Account/IOUData.js
@@ -110,7 +110,7 @@ const LimitsIcon = ({ trustline }) => {
   )
 }
 
-export default function IOUData({ address, rippleStateList, ledgerTimestamp, pageFiatRate, selectedCurrency }) {
+export default function IOUData({ address, rippleStateList, ledgerTimestamp, pageFiatRate, selectedCurrency, account, setSignRequest }) {
   const width = useWidth()
   const { t } = useTranslation()
   const [totalBalance, setTotalBalance] = useState(0)
@@ -184,6 +184,9 @@ export default function IOUData({ address, rippleStateList, ledgerTimestamp, pag
   ]
   */
 
+  // Check if user is logged in (has wallet connected)
+  const isLoggedIn = account?.address && account?.wallet
+
   // amount / gateway details / trustline settings
   const tokenRows = rippleStateList?.length ? (
     rippleStateList.map((tl, i) => {
@@ -240,7 +243,7 @@ export default function IOUData({ address, rippleStateList, ledgerTimestamp, pag
   ) : (
     <tr key="none">
       <td colSpan="100" className="center">
-        This account does not hold any issued tokens.
+        {isLoggedIn ? "You don't hold any tokens." : "This account doesn't have any tokens, login to manage your tokens."}
       </td>
     </tr>
   )
@@ -278,9 +281,22 @@ export default function IOUData({ address, rippleStateList, ledgerTimestamp, pag
           {!rippleStateList?.length && (
             <tr>
               <td className="center" colSpan="100">
-                <Link href={'/services/trustline?address=' + address} className="button-action">
-                  Add a token
-                </Link>
+                {isLoggedIn ? (
+                  address === account?.address ? (
+                  <Link href={'/services/trustline?address=' + address} className="button-action">
+                    Add a token
+                  </Link>
+                  ) : (
+                    ''
+                  )
+                ) : (
+                  <button 
+                    className="button-action"
+                    onClick={() => setSignRequest({ redirect: 'account' })}
+                  >
+                    Log-in
+                  </button>
+                )}
               </td>
             </tr>
           )}
@@ -291,11 +307,6 @@ export default function IOUData({ address, rippleStateList, ledgerTimestamp, pag
         <center>
           {tokensCountText(rippleStateList)}
           {t('menu.tokens').toUpperCase()} {historicalTitle}[<a href={'/explorer/' + address}>Old View</a>]
-          {!rippleStateList?.length && (
-            <>
-              [<a href={'/services/trustline?address=' + address}>Add a token</a>]
-            </>
-          )}
           {totalBalance > 0 && (
             <div>
               <br />
@@ -309,17 +320,43 @@ export default function IOUData({ address, rippleStateList, ledgerTimestamp, pag
         </center>
         <br />
         {
-          <table className="table-mobile wide">
-            <tbody>
-              <tr>
-                <th>#</th>
-                <th className="left">Currency</th>
-                <th className="right">Balance</th>
-                <th className="right">Params</th>
-              </tr>
-              {tokenRows}
-            </tbody>
-          </table>
+          !rippleStateList?.length ? (
+            <>
+              {isLoggedIn ? (
+                <div className="center">
+                  <p>You don't hold any tokens.</p>
+                  { address === account?.address ? (
+                    <>[<a href={'/services/trustline?address=' + address}>Add a token</a>]</>
+                    ) : (
+                      ''
+                    )
+                  }
+                </div>
+              ) : (
+                <div className="center">
+                  <p>This account doesn't have any tokens, login to manage your tokens.</p>
+                  <button 
+                    className="button-action"
+                    onClick={() => setSignRequest({ redirect: 'account' })}
+                  >
+                    Log-in
+                  </button>
+                </div>
+              )}
+            </>
+          ) : (
+            <table className="table-mobile wide">
+              <tbody>
+                <tr>
+                  <th>#</th>
+                  <th className="left">Currency</th>
+                  <th className="right">Balance</th>
+                  <th className="right">Params</th>
+                </tr>
+                {tokenRows}
+              </tbody>
+            </table>
+          )
         }
         <br />
       </div>

--- a/components/Account/IOUData.js
+++ b/components/Account/IOUData.js
@@ -259,11 +259,15 @@ export default function IOUData({ address, rippleStateList, ledgerTimestamp, pag
                 <>
                   [<a href={'/services/trustline?address=' + address}>Add a token</a>]
                 </>
+              ) : (!account?.address && rippleStateList?.length ? (
+                <>
+                  [<a onClick={() => setSignRequest({ redirect: 'account' })}> Login </a>]
+                </>
               ) : (
                 <>
                   [<a href={'/explorer/' + address}>Old View</a>]
                 </>
-              )}
+              ))}
               {totalBalance > 0 && (
                 <span style={{ float: 'right' }}>
                   Total worth:{' '}

--- a/components/Account/IOUData.js
+++ b/components/Account/IOUData.js
@@ -269,13 +269,15 @@ export default function IOUData({ address, rippleStateList, ledgerTimestamp, pag
           </tr>
         </thead>
         <tbody>
-          {rippleStateList?.length && (
+          {rippleStateList?.length ? (
             <tr>
               <th>#</th>
               <th className="left">Currency</th>
               <th className="right">Params</th>
               <th className="right">Balance</th>
             </tr>
+          ) : (
+            ''
           )}
           {tokenRows}
           {!rippleStateList?.length && (

--- a/components/Account/IOUData.js
+++ b/components/Account/IOUData.js
@@ -283,9 +283,9 @@ export default function IOUData({ address, rippleStateList, ledgerTimestamp, pag
               <td className="center" colSpan="100">
                 {isLoggedIn ? (
                   address === account?.address ? (
-                  <Link href={'/services/trustline?address=' + address} className="button-action">
-                    Add a token
-                  </Link>
+                    <Link href={'/services/trustline?address=' + address} className="button-action">
+                      Add a token
+                    </Link>
                   ) : (
                     ''
                   )
@@ -326,7 +326,7 @@ export default function IOUData({ address, rippleStateList, ledgerTimestamp, pag
                 <div className="center">
                   <p>You don't hold any tokens.</p>
                   { address === account?.address ? (
-                    <>[<a href={'/services/trustline?address=' + address}>Add a token</a>]</>
+                      <>[<a href={'/services/trustline?address=' + address}>Add a token</a>]</>
                     ) : (
                       ''
                     )

--- a/components/Account/LedgerData.js
+++ b/components/Account/LedgerData.js
@@ -335,9 +335,9 @@ export default function LedgerData({
         <span>
           You don't have any tokens
         </span>
-        <Link href={'/services/trustline?address=' + data?.address} className="button-action">
+        [<Link href={'/services/trustline?address=' + data?.address}>
           Add a token
-        </Link>
+        </Link>]
       </>
     ) : (
       <span>This account doesn't hold Tokens.</span>
@@ -355,7 +355,7 @@ export default function LedgerData({
       )
     </>
   ) : (
-    "This account doesn't have DEX orders."
+    account?.address === data?.address ? "You don't have any DEX orders." : "This account doesn't have DEX orders."
   )
 
   const escrowNode = !objects?.escrowList ? (
@@ -369,7 +369,16 @@ export default function LedgerData({
       )
     </>
   ) : (
-    "This account doesn't have Escrows."
+    account?.address === data?.address ? (
+      <>
+        <span>You don't have any Escrows.</span>
+        [<Link href={'/services/escrow'}>
+          Create
+        </Link>]
+      </>
+    ) : (
+      "This account doesn't have Escrows."
+    )
   )
 
   return (

--- a/components/Account/LedgerData.js
+++ b/components/Account/LedgerData.js
@@ -330,7 +330,18 @@ export default function LedgerData({
       )
     </>
   ) : (
-    "This account doesn't hold Tokens."
+    account?.address === data?.address ? (
+      <>
+        <span>
+          You don't have any tokens
+        </span>
+        <Link href={'/services/trustline?address=' + data?.address} className="button-action">
+          Add a token
+        </Link>
+      </>
+    ) : (
+      <span>This account doesn't hold Tokens.</span>
+    )
   )
 
   const dexOrdersNode = !objects?.offerList ? (

--- a/pages/account/[id].js
+++ b/pages/account/[id].js
@@ -578,6 +578,8 @@ export default function Account({
                               address={data?.address}
                               pageFiatRate={pageFiatRate}
                               selectedCurrency={selectedCurrency}
+                              account={account}
+                              setSignRequest={setSignRequest}
                             />
                           </div>
                           {/* don't show yet obligations historically */}


### PR DESCRIPTION
# Issue
[1. when user logged in show, “You don’t hold any tokens”, and a button “Add a token”
when logged out - This account doesn’t have any tokens, login to manage your tokens. button “Log-in”
2. when ledger data shows: "This account doesn't hold Tokens.", we need to show "You don't have any tokens" and "Add a token" link, when user is logged in.
3. for dex orders and escrows, when logged in, we need to change text as well, "You don't have any Ewscrows." and link "Create"
4. in tokens: for limit we show icon of a graph, lets change icon to a i - like information in a circle, that will be similiar to what we had in the old explorer view.
5. lets replace the link to the [OLD VIEW] to the [ADD A TOKEN] - when logged in (and when user has tokens already)
when logged out - [Login] to manage your tokens.](https://github.com/Bithomp/frontend-react/issues/590)